### PR TITLE
2.8.6

### DIFF
--- a/Samples/ExportNetworkStatsXmlRpcSample/Program.cs
+++ b/Samples/ExportNetworkStatsXmlRpcSample/Program.cs
@@ -14,9 +14,9 @@ var logger = LoggerFactory.Create(builder =>
 
 using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1", logger: logger);
 
-object?[] authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
+object? authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
 
-if (authenticationResult is not [true])
+if (authenticationResult is not true)
 {
     throw new Exception("Authentication failed.");
 }

--- a/Src/ManiaAPI.NadeoAPI.Extensions.Hosting/ManiaAPI.NadeoAPI.Extensions.Hosting.csproj
+++ b/Src/ManiaAPI.NadeoAPI.Extensions.Hosting/ManiaAPI.NadeoAPI.Extensions.Hosting.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>ManiaAPI.NadeoAPI.Extensions.Hosting</PackageId>
-        <Version>2.8.5</Version>
+        <Version>2.8.6</Version>
         <Authors>BigBang1112</Authors>
         <Description>Extension methods of Nadeo API for ASP.NET Core. Part of the ManiaAPI.NET library set.</Description>
         <Copyright>Copyright (c) 2022-2026 Petr Pivoňka</Copyright>

--- a/Src/ManiaAPI.NadeoAPI.Extensions.Hosting/NadeoAPIRefreshBackgroundService.cs
+++ b/Src/ManiaAPI.NadeoAPI.Extensions.Hosting/NadeoAPIRefreshBackgroundService.cs
@@ -16,7 +16,7 @@ internal class NadeoAPIRefreshBackgroundService : BackgroundService
     {
         while (!stoppingToken.IsCancellationRequested)
         {
-            await Task.Delay(TimeSpan.FromHours(20), stoppingToken);
+            await Task.Delay(TimeSpan.FromHours(6), stoppingToken);
 
             await using var scope = scopeFactory.CreateAsyncScope();
 

--- a/Src/ManiaAPI.Xml/MP4/MasterServerMP4.cs
+++ b/Src/ManiaAPI.Xml/MP4/MasterServerMP4.cs
@@ -633,9 +633,11 @@ public class MasterServerMP4 : MasterServerMP, IMasterServerMP4
         using var ms = new MemoryStream(Convert.FromBase64String(xml.ReadContentAsString()));
         using var r = new GbxBasedReader(ms, leaveOpen: false);
 
-        var records = ImmutableArray.CreateBuilder<LeaderboardItem<T>>(r.ReadInt32());
+        var count = r.ReadInt32();
 
-        for (int i = 0; i < records.Count; i++)
+        var records = new LeaderboardItem<T>[count];
+
+        for (int i = 0; i < count; i++)
         {
             var rank = r.ReadInt32();
             var score = r.ReadUInt32();
@@ -649,6 +651,6 @@ public class MasterServerMP4 : MasterServerMP, IMasterServerMP4
             records[i] = new LeaderboardItem<T>(rank, login, nickname, scoreValue, fileName, replayUrl);
         }
 
-        return records.ToImmutable();
+        return records.ToImmutableArray();
     }
 }

--- a/Src/ManiaAPI.Xml/MP4/MasterServerMP4.cs
+++ b/Src/ManiaAPI.Xml/MP4/MasterServerMP4.cs
@@ -78,6 +78,17 @@ public interface IMasterServerMP4 : IMasterServerMP
     /// Gets multiple campaign leaderboard summaries in a single request.
     /// </summary>
     /// <param name="titleId">The title ID of a title pack.</param>
+    /// <param name="campaignId">The ID of the campaign.</param>
+    /// <param name="zone">The zone to retrieve the leaderboard from.</param>
+    /// <param name="type">The type of leaderboard.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task with the result containing the campaign summaries.</returns>
+    Task<MasterServerResponse<ImmutableList<CampaignSummary>>> GetCampaignLeaderBoardSummariesResponseAsync(string titleId, string? campaignId = null, string zone = "World", CampaignLeaderboardType type = CampaignLeaderboardType.SkillPoint, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets multiple campaign leaderboard summaries in a single request.
+    /// </summary>
+    /// <param name="titleId">The title ID of a title pack.</param>
     /// <param name="summaries">The list of campaign requests.</param>
     /// <returns>A task with the result containing the campaign summaries.</returns>
     Task<MasterServerResponse<ImmutableList<CampaignSummary>>> GetCampaignLeaderBoardSummariesResponseAsync(string titleId, params IEnumerable<CampaignSummaryRequest> summaries);
@@ -90,6 +101,17 @@ public interface IMasterServerMP4 : IMasterServerMP
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task with the result containing the campaign summaries.</returns>
     Task<ImmutableList<CampaignSummary>> GetCampaignLeaderBoardSummariesAsync(string titleId, IEnumerable<CampaignSummaryRequest> summaries, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets multiple campaign leaderboard summaries in a single request.
+    /// </summary>
+    /// <param name="titleId">The title ID of a title pack.</param>
+    /// <param name="campaignId">The ID of the campaign.</param>
+    /// <param name="zone">The zone to retrieve the leaderboard from.</param>
+    /// <param name="type">The type of leaderboard.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task with the result containing the campaign summaries.</returns>
+    Task<CampaignSummary> GetCampaignLeaderBoardSummariesAsync(string titleId, string? campaignId = null, string zone = "World", CampaignLeaderboardType type = CampaignLeaderboardType.SkillPoint, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets multiple campaign leaderboard summaries in a single request.
@@ -113,6 +135,19 @@ public interface IMasterServerMP4 : IMasterServerMP
     /// Gets multiple map leaderboard summaries in a single request.
     /// </summary>
     /// <param name="titleId">The title ID of a title pack.</param>
+    /// <param name="mapUid">The unique ID of the map.</param>
+    /// <param name="zone">The zone to retrieve the leaderboard from.</param>
+    /// <param name="context">The context for the leaderboard.</param>
+    /// <param name="type">The type of leaderboard.</param>
+    /// <param name="isBinary">Whether to use binary format for scores (smaller payload) or XML format (larger payload). Default is <see langword="true"/> as it is objectively better, but you can set this to <see langword="false"/> to skip a cache once.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task with the result containing the map summaries.</returns>
+    Task<MasterServerResponse<ImmutableList<MapSummary>>> GetMapLeaderBoardSummariesResponseAsync(string titleId, string mapUid, string zone = "World", string context = "", MapLeaderboardType type = MapLeaderboardType.MapRecord, bool isBinary = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets multiple map leaderboard summaries in a single request.
+    /// </summary>
+    /// <param name="titleId">The title ID of a title pack.</param>
     /// <param name="summaries">The list of map requests.</param>
     /// <returns>A task with the result containing the map summaries.</returns>
     Task<MasterServerResponse<ImmutableList<MapSummary>>> GetMapLeaderBoardSummariesResponseAsync(string titleId, params IEnumerable<MapSummaryRequest> summaries);
@@ -126,6 +161,19 @@ public interface IMasterServerMP4 : IMasterServerMP
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task with the result containing the map summaries.</returns>
     Task<ImmutableList<MapSummary>> GetMapLeaderBoardSummariesAsync(string titleId, IEnumerable<MapSummaryRequest> summaries, bool isBinary = true, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets multiple map leaderboard summaries in a single request.
+    /// </summary>
+    /// <param name="titleId">The title ID of a title pack.</param>
+    /// <param name="mapUid">The unique ID of the map.</param>
+    /// <param name="zone">The zone to retrieve the leaderboard from.</param>
+    /// <param name="context">The context for the leaderboard.</param>
+    /// <param name="type">The type of leaderboard.</param>
+    /// <param name="isBinary">Whether to use binary format for scores (smaller payload) or XML format (larger payload). Default is <see langword="true"/> as it is objectively better, but you can set this to <see langword="false"/> to skip a cache once.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task with the result containing the map summary.</returns>
+    Task<MapSummary> GetMapLeaderBoardSummariesAsync(string titleId, string mapUid, string zone = "World", string context = "", MapLeaderboardType type = MapLeaderboardType.MapRecord, bool isBinary = true, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets multiple map leaderboard summaries in a single request.
@@ -325,6 +373,16 @@ public class MasterServerMP4 : MasterServerMP, IMasterServerMP4
         return await GetCampaignLeaderBoardSummariesResponseAsync(titleId, summaries, cancellationToken: default);
     }
 
+    public async Task<MasterServerResponse<ImmutableList<CampaignSummary>>> GetCampaignLeaderBoardSummariesResponseAsync(
+        string titleId,
+        string? campaignId = null,
+        string zone = "World",
+        CampaignLeaderboardType type = CampaignLeaderboardType.SkillPoint,
+        CancellationToken cancellationToken = default)
+    {
+        return await GetCampaignLeaderBoardSummariesResponseAsync(titleId, [new CampaignSummaryRequest(campaignId, zone, type)], cancellationToken);
+    }
+
     public async Task<ImmutableList<CampaignSummary>> GetCampaignLeaderBoardSummariesAsync(
         string titleId,
         IEnumerable<CampaignSummaryRequest> summaries,
@@ -338,6 +396,17 @@ public class MasterServerMP4 : MasterServerMP, IMasterServerMP4
         params IEnumerable<CampaignSummaryRequest> summaries)
     {
         return await GetCampaignLeaderBoardSummariesAsync(titleId, summaries, cancellationToken: default);
+    }
+
+    public async Task<CampaignSummary> GetCampaignLeaderBoardSummariesAsync(
+        string titleId,
+        string? campaignId = null,
+        string zone = "World",
+        CampaignLeaderboardType type = CampaignLeaderboardType.SkillPoint,
+        CancellationToken cancellationToken = default)
+    {
+        var summaries = await GetCampaignLeaderBoardSummariesAsync(titleId, [new CampaignSummaryRequest(campaignId, zone, type)], cancellationToken);
+        return summaries.FirstOrDefault() ?? throw new InvalidOperationException("No campaign summary found.");
     }
 
     public virtual async Task<MasterServerResponse<ImmutableList<MapSummary>>> GetMapLeaderBoardSummariesResponseAsync(
@@ -441,6 +510,18 @@ public class MasterServerMP4 : MasterServerMP, IMasterServerMP4
 
     public async Task<MasterServerResponse<ImmutableList<MapSummary>>> GetMapLeaderBoardSummariesResponseAsync(
         string titleId,
+        string mapUid,
+        string zone = "World",
+        string context = "",
+        MapLeaderboardType type = MapLeaderboardType.MapRecord,
+        bool isBinary = true,
+        CancellationToken cancellationToken = default)
+    {
+        return await GetMapLeaderBoardSummariesResponseAsync(titleId, [new MapSummaryRequest(mapUid, zone, context, type)], isBinary, cancellationToken);
+    }
+
+    public async Task<MasterServerResponse<ImmutableList<MapSummary>>> GetMapLeaderBoardSummariesResponseAsync(
+        string titleId,
         params IEnumerable<MapSummaryRequest> summaries)
     {
         return await GetMapLeaderBoardSummariesResponseAsync(titleId, summaries, isBinary: true, cancellationToken: default);
@@ -453,6 +534,19 @@ public class MasterServerMP4 : MasterServerMP, IMasterServerMP4
         CancellationToken cancellationToken = default)
     {
         return (await GetMapLeaderBoardSummariesResponseAsync(titleId, summaries, isBinary, cancellationToken)).Result;
+    }
+
+    public async Task<MapSummary> GetMapLeaderBoardSummariesAsync(
+        string titleId,
+        string mapUid,
+        string zone = "World",
+        string context = "",
+        MapLeaderboardType type = MapLeaderboardType.MapRecord,
+        bool isBinary = true,
+        CancellationToken cancellationToken = default)
+    {
+        var summaries = await GetMapLeaderBoardSummariesAsync(titleId, [new MapSummaryRequest(mapUid, zone, context, type)], isBinary, cancellationToken);
+        return summaries.FirstOrDefault() ?? throw new InvalidOperationException("No map summary found.");
     }
 
     public async Task<ImmutableList<MapSummary>> GetMapLeaderBoardSummariesAsync(

--- a/Src/ManiaAPI.Xml/ManiaAPI.Xml.csproj
+++ b/Src/ManiaAPI.Xml/ManiaAPI.Xml.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<PackageId>ManiaAPI.Xml</PackageId>
-		<Version>2.8.5</Version>
+		<Version>2.8.6</Version>
 		<Authors>BigBang1112</Authors>
 		<Description>Wrapper for the XML API used in TMF and ManiaPlanet. Part of the ManiaAPI.NET library set.</Description>
 		<Copyright>Copyright (c) 2022-2026 Petr Pivoňka</Copyright>

--- a/Src/ManiaAPI.XmlRpc/ManiaAPI.XmlRpc.csproj
+++ b/Src/ManiaAPI.XmlRpc/ManiaAPI.XmlRpc.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>ManiaAPI.XmlRpc</PackageId>
-        <Version>2.8.4</Version>
+        <Version>2.8.6</Version>
         <Authors>BigBang1112</Authors>
         <Description>Integrates the XML-RPC communication used between controllers and servers. Part of the ManiaAPI.NET library set.</Description>
         <Copyright>Copyright (c) 2022-2026 Petr Pivoňka</Copyright>

--- a/Src/ManiaAPI.XmlRpc/XmlRpcCallback.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcCallback.cs
@@ -1,3 +1,3 @@
 ﻿namespace ManiaAPI.XmlRpc;
 
-public delegate Task XmlRpcCallback(string methodName, object?[] methodParams);
+public delegate Task XmlRpcCallback(string methodName, object?[] methodParams, CancellationToken cancellationToken = default);

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.Methods.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.Methods.cs
@@ -6,7 +6,7 @@ public partial class XmlRpcClient
     {
         var result = await CallAsync("system.listMethods", cancellationToken);
 
-        if (result is not [IEnumerable<object> methods])
+        if (result is not IEnumerable<object> methods)
         {
             throw new XmlRpcClientException("Invalid response from system.listMethods.");
         }
@@ -18,7 +18,7 @@ public partial class XmlRpcClient
     {
         var result = await CallAsync("system.methodSignature", [methodName], cancellationToken);
 
-        if (result is not [IEnumerable<object> signatures])
+        if (result is not IEnumerable<object> signatures)
         {
             throw new XmlRpcClientException($"Invalid response from system.methodSignature for method '{methodName}'.");
         }
@@ -32,11 +32,49 @@ public partial class XmlRpcClient
     {
         var result = await CallAsync("system.methodHelp", [methodName], cancellationToken);
 
-        if (result is not [string help])
+        if (result is not string help)
         {
             throw new XmlRpcClientException($"Invalid response from system.methodHelp for method '{methodName}'.");
         }
 
         return help;
+    }
+
+    public async Task<IEnumerable<XmlRpcMulticallResult>> SystemMulticallAsync(IEnumerable<XmlRpcMulticall> calls, CancellationToken cancellationToken = default)
+    {
+        var multicallParams = calls
+            .Select(call => new Dictionary<string, object?>
+            {
+                ["methodName"] = call.MethodName,
+                ["params"] = call.Parameters
+            })
+            .ToArray();
+
+        var result = await CallAsync("system.multicall", [multicallParams], cancellationToken);
+
+        if (result is not IEnumerable<object> results)
+        {
+            throw new XmlRpcClientException("Invalid response from system.multicall.");
+        }
+
+        return results.Select(ParseMulticallResult);
+    }
+
+    private static XmlRpcMulticallResult ParseMulticallResult(object item)
+    {
+        if (item is IEnumerable<object?> success)
+        {
+            return new XmlRpcMulticallResult(success.FirstOrDefault(), FaultCode: null, FaultString: null);
+        }
+
+        if (item is IDictionary<string, object?> fault)
+        {
+            return new XmlRpcMulticallResult(
+                Value: null,
+                FaultCode: fault.TryGetValue("faultCode", out var code) ? code as int? : null,
+                FaultString: fault.TryGetValue("faultString", out var faultString) ? faultString as string : null);
+        }
+
+        throw new XmlRpcClientException("Invalid item in system.multicall response.");
     }
 }

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -203,7 +203,7 @@ public partial class XmlRpcClient : IDisposable
 
             if (Callback is not null)
             {
-                await Callback.Invoke(methodName, parameters);
+                await Callback.Invoke(methodName, parameters, cancellationToken);
             }
         }
     }

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using MinimalXmlReader;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
@@ -391,9 +392,16 @@ public partial class XmlRpcClient : IDisposable
 
     private static void AppendXmlRpcParam<T>(StringBuilder sb, T param)
     {
-        sb.Append("<param><value>");
+        sb.Append("<param>");
+        AppendXmlRpcValue(sb, param);
+        sb.Append("</param>");
+    }
 
-        switch (param)
+    private static void AppendXmlRpcValue<T>(StringBuilder sb, T value)
+    {
+        sb.Append("<value>");
+
+        switch (value)
         {
             case int integer:
                 sb.Append("<int>");
@@ -418,12 +426,32 @@ public partial class XmlRpcClient : IDisposable
             case string str:
                 sb.Append(str);
                 break;
+            case IDictionary<string, object?> dict:
+                sb.Append("<struct>");
+                foreach (var member in dict)
+                {
+                    sb.Append("<member><name>");
+                    sb.Append(member.Key);
+                    sb.Append("</name>");
+                    AppendXmlRpcValue(sb, member.Value);
+                    sb.Append("</member>");
+                }
+                sb.Append("</struct>");
+                break;
+            case IEnumerable enumerable:
+                sb.Append("<array><data>");
+                foreach (var item in enumerable)
+                {
+                    AppendXmlRpcValue(sb, item);
+                }
+                sb.Append("</data></array>");
+                break;
             default:
-                sb.Append(param);
+                sb.Append(value);
                 break;
         }
 
-        sb.Append("</value></param>");
+        sb.Append("</value>");
     }
 
     private async Task<uint> SendXmlPayloadAsync(string xmlPayload, CancellationToken cancellationToken)

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -228,14 +228,14 @@ public partial class XmlRpcClient : IDisposable
         return await CallXmlAsync(methodName, [], cancellationToken);
     }
 
-    public async Task<object?[]> CallAsync(string methodName, object?[] methodParams, CancellationToken cancellationToken = default)
+    public async Task<object?> CallAsync(string methodName, object?[] methodParams, CancellationToken cancellationToken = default)
     {
         var xmlResult = await CallXmlAsync(methodName, methodParams, cancellationToken);
 
         return ParseXmlRpcMethodResponse(xmlResult);
     }
 
-    public async Task<object?[]> CallAsync(string methodName, CancellationToken cancellationToken = default)
+    public async Task<object?> CallAsync(string methodName, CancellationToken cancellationToken = default)
     {
         return await CallAsync(methodName, [], cancellationToken);
     }
@@ -273,14 +273,15 @@ public partial class XmlRpcClient : IDisposable
         return pendingRequests.GetOrAdd(handle, _ => Channel.CreateBounded<string>(1));
     }
 
-    private static object?[] ParseXmlRpcMethodResponse(string xml)
+    private static object? ParseXmlRpcMethodResponse(string xml)
     {
         var r = new MiniXmlReader(xml);
 
         _ = r.SkipProcessingInstruction();
         _ = r.SkipStartElement("methodResponse");
 
-        return ReadXmlRpcParams(xml, ref r);
+        var parameters = ReadXmlRpcParams(xml, ref r);
+        return parameters.Length == 1 ? parameters[0] : parameters;
     }
 
     private static object?[] ReadXmlRpcParams(string xml, ref MiniXmlReader r)

--- a/Src/ManiaAPI.XmlRpc/XmlRpcMulticall.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcMulticall.cs
@@ -1,0 +1,15 @@
+﻿namespace ManiaAPI.XmlRpc;
+
+/// <summary>
+/// Represents a single method call to be executed as part of a <c>system.multicall</c> request.
+/// </summary>
+/// <param name="MethodName">The name of the method to call.</param>
+/// <param name="Parameters">The parameters to pass to the method.</param>
+public readonly record struct XmlRpcMulticall(string MethodName, object?[] Parameters)
+{
+    /// <summary>
+    /// Creates a multicall entry for a method that takes no parameters.
+    /// </summary>
+    /// <param name="methodName">The name of the method to call.</param>
+    public XmlRpcMulticall(string methodName) : this(methodName, []) { }
+}

--- a/Src/ManiaAPI.XmlRpc/XmlRpcMulticallResult.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcMulticallResult.cs
@@ -1,0 +1,17 @@
+﻿namespace ManiaAPI.XmlRpc;
+
+/// <summary>
+/// Represents the outcome of a single call executed through <c>system.multicall</c>.
+/// If the call succeeded, <see cref="Value"/> contains the returned value.
+/// If it failed, <see cref="FaultCode"/> and <see cref="FaultString"/> describe the fault.
+/// </summary>
+/// <param name="Value">The value returned by the method call, if it succeeded.</param>
+/// <param name="FaultCode">The fault code, if the call failed.</param>
+/// <param name="FaultString">The fault description, if the call failed.</param>
+public readonly record struct XmlRpcMulticallResult(object? Value, int? FaultCode, string? FaultString)
+{
+    /// <summary>
+    /// Indicates whether the call failed.
+    /// </summary>
+    public bool IsFault => FaultString is not null;
+}

--- a/Tests/ManiaAPI.Xml.Tests/Integration/MasterServerMP4Tests.cs
+++ b/Tests/ManiaAPI.Xml.Tests/Integration/MasterServerMP4Tests.cs
@@ -106,6 +106,7 @@ public class MasterServerMP4Tests
             [new(), new(Zone: "World|Europe")]);
 
         Assert.NotEmpty(summaries);
+        Assert.NotEmpty(summaries[0].HighScores);
     }
 
     [Fact]
@@ -117,6 +118,7 @@ public class MasterServerMP4Tests
             [new("JNDnboltOprJ19O2d2OQCJrC1Sk"), new("f60UDPlW2mqfbhwCGUuclCIYQj2")]);
 
         Assert.NotEmpty(summaries);
+        Assert.NotEmpty(summaries[0].HighScores);
     }
 
     [Fact]


### PR DESCRIPTION
ManiaAPI.XmlRpc
- Added `SystemMulticallAsync`
- Added `CancellationToken` to callback
- Fixed `CallAsync` to return `object?` instead of `object?[]` with always one result

ManiaAPI.Xml
- Added simpler single-item-list wrappers to MP4 requests

ManiaAPI.NadeoAPI.Extensions.Hosting
- Job refreshes every 6 hours instead of 20 hours, to protect against non-retry setups