### PR TITLE
GBXRemote improvements

### DIFF
--- a/ManiaAPI.NET.slnx
+++ b/ManiaAPI.NET.slnx
@@ -11,6 +11,7 @@
     <File Path="README.md" />
   </Folder>
   <Folder Name="/Samples/">
+    <Project Path="Samples/CallbackListenerXmlRpcSample/CallbackListenerXmlRpcSample.csproj" Id="21b593b7-e1eb-45f4-a279-90dd873c4cb8" />
     <Project Path="Samples/ExportMethodsXmlRpcSample/ExportMethodsXmlRpcSample.csproj" />
     <Project Path="Samples/ExportNetworkStatsXmlRpcSample/ExportNetworkStatsXmlRpcSample.csproj" Id="7419d5a4-8359-4aed-bce4-80dcbb78d0c3" />
     <Project Path="Samples/ExtendApiSample/ExtendApiSample.csproj" />

--- a/README.md
+++ b/README.md
@@ -849,16 +849,23 @@ This solution tries to be lightweight and compatible with as many Nadeo games as
 ```cs
 using ManiaAPI.XmlRpc;
 
-using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1");
+await using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1");
 
-object?[] authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
+object? authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
 
-if (authenticationResult is not [true])
+if (authenticationResult is not true)
 {
     throw new Exception("Authentication failed.");
 }
 
-object?[] result = await xmlRpc.CallAsync("GameDataDirectory");
+object? result = await xmlRpc.CallAsync("GameDataDirectory");
+
+if (result is not string gameDataDirectory)
+{
+    throw new Exception("Failed to retrieve game data directory.");
+}
+
+Console.WriteLine($"Game data directory: {gameDataDirectory}");
 ```
 
 ## ManiaAPI.UnitedLadder

--- a/README.md
+++ b/README.md
@@ -838,9 +838,11 @@ Features this last setup brings:
 
 [![NuGet](https://img.shields.io/nuget/vpre/ManiaAPI.XmlRpc?style=for-the-badge&logo=nuget)](https://www.nuget.org/packages/ManiaAPI.XmlRpc/)
 
-Integrates the XML-RPC communication used between controllers and servers.
+Integrates the GBXRemote (XML-RPC) communication used between controllers and servers.
 
-This solution tries to be lightweight and compatible with as many Nadeo games as possible. For a better strongly-typed XML-RPC, use the [GbxRemote.Net](https://github.com/EvoEsports/GbxRemote.Net) library.
+Both versions (`GBXRemote 2` and `GBXRemote 1`) are supported.
+
+This solution tries to be lightweight and compatible with as many Nadeo games as possible. For a better strongly-typed GBXRemote, use the [GbxRemote.Net](https://github.com/EvoEsports/GbxRemote.Net) library.
 
 **This package is still experimental, the API can change drastically.**
 
@@ -858,14 +860,34 @@ if (authenticationResult is not true)
     throw new Exception("Authentication failed.");
 }
 
-object? result = await xmlRpc.CallAsync("GameDataDirectory");
+object? gameDataResult = await xmlRpc.CallAsync("GameDataDirectory");
 
-if (result is not string gameDataDirectory)
+if (gameDataResult is not string gameDataDirectory)
 {
     throw new Exception("Failed to retrieve game data directory.");
 }
 
 Console.WriteLine($"Game data directory: {gameDataDirectory}");
+```
+
+For callbacks:
+
+```cs
+object? enableCallbacksResult = await xmlRpc.CallAsync("EnableCallbacks", true);
+
+if (enableCallbacksResult is not true)
+{
+    throw new Exception("Failed to enable callbacks.");
+}
+
+// Subscribe to callbacks
+xmlRpc.Callback += async (methodName, methodParams, cancellationToken) =>
+{
+    Console.WriteLine($"{methodName}: {string.Join(", ", methodParams)}");
+};
+
+// Keep the connection until the server closes it
+await xmlRpc.WaitForCloseAsync();
 ```
 
 ## ManiaAPI.UnitedLadder

--- a/README.md
+++ b/README.md
@@ -851,16 +851,16 @@ This solution tries to be lightweight and compatible with as many Nadeo games as
 ```cs
 using ManiaAPI.XmlRpc;
 
-await using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1");
+await using var client = await XmlRpcClient.ConnectAsync("127.0.0.1");
 
-object? authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
+object? authenticationResult = await client.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
 
 if (authenticationResult is not true)
 {
     throw new Exception("Authentication failed.");
 }
 
-object? gameDataResult = await xmlRpc.CallAsync("GameDataDirectory");
+object? gameDataResult = await client.CallAsync("GameDataDirectory");
 
 if (gameDataResult is not string gameDataDirectory)
 {
@@ -873,7 +873,7 @@ Console.WriteLine($"Game data directory: {gameDataDirectory}");
 For callbacks:
 
 ```cs
-object? enableCallbacksResult = await xmlRpc.CallAsync("EnableCallbacks", true);
+object? enableCallbacksResult = await client.CallAsync("EnableCallbacks", true);
 
 if (enableCallbacksResult is not true)
 {
@@ -881,10 +881,15 @@ if (enableCallbacksResult is not true)
 }
 
 // Subscribe to callbacks
-xmlRpc.Callback += async (methodName, methodParams, cancellationToken) =>
+client.Callback += async (methodName, methodParams, cancellationToken) =>
 {
     Console.WriteLine($"{methodName}: {string.Join(", ", methodParams)}");
 };
+
+client.On("TrackMania.PlayerConnect", async (methodParams, cancellationToken) => 
+{
+    // ...
+});
 
 // Keep the connection until the server closes it
 await xmlRpc.WaitForCloseAsync();

--- a/Samples/CallbackListenerXmlRpcSample/CallbackListenerXmlRpcSample.csproj
+++ b/Samples/CallbackListenerXmlRpcSample/CallbackListenerXmlRpcSample.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PublishAot>true</PublishAot>
+        <InvariantGlobalization>true</InvariantGlobalization>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Src\ManiaAPI.XmlRpc\ManiaAPI.XmlRpc.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Samples/CallbackListenerXmlRpcSample/Program.cs
+++ b/Samples/CallbackListenerXmlRpcSample/Program.cs
@@ -1,0 +1,22 @@
+﻿using ManiaAPI.XmlRpc;
+using Microsoft.Extensions.Logging;
+
+var logger = LoggerFactory.Create(builder =>
+{
+    builder.AddSimpleConsole(options =>
+    {
+        options.IncludeScopes = true;
+        options.SingleLine = true;
+    });
+    builder.SetMinimumLevel(LogLevel.Trace);
+}).CreateLogger<XmlRpcClient>();
+
+using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1", logger: logger);
+
+await xmlRpc.CallAsync("Authenticate", "SuperAdmin", "SuperAdmin");
+await xmlRpc.CallAsync("EnableCallbacks", true);
+
+await foreach (var callback in xmlRpc.StreamCallbacksAsync())
+{
+    Console.WriteLine($"{callback.MethodName}: {string.Join(", ", callback.MethodParams)}");
+}

--- a/Samples/CallbackListenerXmlRpcSample/Program.cs
+++ b/Samples/CallbackListenerXmlRpcSample/Program.cs
@@ -8,7 +8,7 @@ var logger = LoggerFactory.Create(builder =>
         options.IncludeScopes = true;
         options.SingleLine = true;
     });
-    builder.SetMinimumLevel(LogLevel.Trace);
+    builder.SetMinimumLevel(LogLevel.Warning);
 }).CreateLogger<XmlRpcClient>();
 
 using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1", logger: logger);

--- a/Samples/ExportMethodsXmlRpcSample/Program.cs
+++ b/Samples/ExportMethodsXmlRpcSample/Program.cs
@@ -15,6 +15,9 @@ using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1", logger: logger);
 
 var methods = await xmlRpc.SystemListMethodsAsync();
 
+// Note: this is a rather slow approach to achieve the goal
+// for real scenarios, you would want to call SystemMulticallAsync
+// with system.methodSignature and system.methodHelp for all methods listed
 foreach (var method in methods)
 {
     var signatures = await xmlRpc.SystemMethodSignatureAsync(method);

--- a/Src/ManiaAPI.XmlRpc/ManiaAPI.XmlRpc.csproj
+++ b/Src/ManiaAPI.XmlRpc/ManiaAPI.XmlRpc.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>ManiaAPI.XmlRpc</PackageId>
-        <Version>2.8.6</Version>
+        <Version>2.8.7</Version>
         <Authors>BigBang1112</Authors>
         <Description>Integrates the XML-RPC communication used between controllers and servers. Part of the ManiaAPI.NET library set.</Description>
         <Copyright>Copyright (c) 2022-2026 Petr Pivoňka</Copyright>

--- a/Src/ManiaAPI.XmlRpc/README.md
+++ b/Src/ManiaAPI.XmlRpc/README.md
@@ -2,9 +2,11 @@
 
 [![NuGet](https://img.shields.io/nuget/vpre/ManiaAPI.XmlRpc?style=for-the-badge&logo=nuget)](https://www.nuget.org/packages/ManiaAPI.XmlRpc/)
 
-Integrates the XML-RPC communication used between controllers and servers.
+Integrates the GBXRemote (XML-RPC) communication used between controllers and servers.
 
-This solution tries to be lightweight and compatible with as many Nadeo games as possible. For a better strongly-typed XML-RPC, use the [GbxRemote.Net](https://github.com/EvoEsports/GbxRemote.Net) library.
+Both versions (`GBXRemote 2` and `GBXRemote 1`) are supported.
+
+This solution tries to be lightweight and compatible with as many Nadeo games as possible. For a better strongly-typed GBXRemote, use the [GbxRemote.Net](https://github.com/EvoEsports/GbxRemote.Net) library.
 
 **This package is still experimental, the API can change drastically.**
 
@@ -22,12 +24,32 @@ if (authenticationResult is not true)
     throw new Exception("Authentication failed.");
 }
 
-object? result = await xmlRpc.CallAsync("GameDataDirectory");
+object? gameDataResult = await xmlRpc.CallAsync("GameDataDirectory");
 
-if (result is not string gameDataDirectory)
+if (gameDataResult is not string gameDataDirectory)
 {
     throw new Exception("Failed to retrieve game data directory.");
 }
 
 Console.WriteLine($"Game data directory: {gameDataDirectory}");
+```
+
+For callbacks:
+
+```cs
+object? enableCallbacksResult = await xmlRpc.CallAsync("EnableCallbacks", true);
+
+if (enableCallbacksResult is not true)
+{
+    throw new Exception("Failed to enable callbacks.");
+}
+
+// Subscribe to callbacks
+xmlRpc.Callback += async (methodName, methodParams, cancellationToken) =>
+{
+    Console.WriteLine($"{methodName}: {string.Join(", ", methodParams)}");
+};
+
+// Keep the connection until the server closes it
+await xmlRpc.WaitForCloseAsync();
 ```

--- a/Src/ManiaAPI.XmlRpc/README.md
+++ b/Src/ManiaAPI.XmlRpc/README.md
@@ -15,16 +15,16 @@ This solution tries to be lightweight and compatible with as many Nadeo games as
 ```cs
 using ManiaAPI.XmlRpc;
 
-await using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1");
+await using var client = await XmlRpcClient.ConnectAsync("127.0.0.1");
 
-object? authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
+object? authenticationResult = await client.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
 
 if (authenticationResult is not true)
 {
     throw new Exception("Authentication failed.");
 }
 
-object? gameDataResult = await xmlRpc.CallAsync("GameDataDirectory");
+object? gameDataResult = await client.CallAsync("GameDataDirectory");
 
 if (gameDataResult is not string gameDataDirectory)
 {
@@ -37,7 +37,7 @@ Console.WriteLine($"Game data directory: {gameDataDirectory}");
 For callbacks:
 
 ```cs
-object? enableCallbacksResult = await xmlRpc.CallAsync("EnableCallbacks", true);
+object? enableCallbacksResult = await client.CallAsync("EnableCallbacks", true);
 
 if (enableCallbacksResult is not true)
 {
@@ -45,10 +45,15 @@ if (enableCallbacksResult is not true)
 }
 
 // Subscribe to callbacks
-xmlRpc.Callback += async (methodName, methodParams, cancellationToken) =>
+client.Callback += async (methodName, methodParams, cancellationToken) =>
 {
     Console.WriteLine($"{methodName}: {string.Join(", ", methodParams)}");
 };
+
+client.On("TrackMania.PlayerConnect", async (methodParams, cancellationToken) => 
+{
+    // ...
+});
 
 // Keep the connection until the server closes it
 await xmlRpc.WaitForCloseAsync();

--- a/Src/ManiaAPI.XmlRpc/README.md
+++ b/Src/ManiaAPI.XmlRpc/README.md
@@ -13,14 +13,21 @@ This solution tries to be lightweight and compatible with as many Nadeo games as
 ```cs
 using ManiaAPI.XmlRpc;
 
-using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1");
+await using var xmlRpc = await XmlRpcClient.ConnectAsync("127.0.0.1");
 
-object?[] authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
+object? authenticationResult = await xmlRpc.CallAsync("Authenticate", ["SuperAdmin", "SuperAdmin"]);
 
-if (authenticationResult is not [true])
+if (authenticationResult is not true)
 {
     throw new Exception("Authentication failed.");
 }
 
-object?[] result = await xmlRpc.CallAsync("GameDataDirectory");
+object? result = await xmlRpc.CallAsync("GameDataDirectory");
+
+if (result is not string gameDataDirectory)
+{
+    throw new Exception("Failed to retrieve game data directory.");
+}
+
+Console.WriteLine($"Game data directory: {gameDataDirectory}");
 ```

--- a/Src/ManiaAPI.XmlRpc/XmlRpcCallbackMessage.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcCallbackMessage.cs
@@ -1,0 +1,3 @@
+﻿namespace ManiaAPI.XmlRpc;
+
+public sealed record XmlRpcCallbackMessage(string MethodName, object?[] MethodParams);

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -503,6 +503,23 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Waits until the connection is closed, whether because the client was disposed,
+    /// the remote host closed it, or an error occurred while listening for messages.
+    /// </summary>
+    /// <param name="cancellationToken">A token that, when canceled, stops waiting without closing the connection.</param>
+    public async Task WaitForCloseAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await ListenTask.WaitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException ex) when (ex.CancellationToken != cancellationToken)
+        {
+            // The listen loop stopped because the client was disposed - this is a normal closure.
+        }
+    }
+
     public void Dispose()
     {
         cts.Cancel();

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -30,8 +30,8 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     private readonly Channel<KeyValuePair<uint, string>> callbackChannel = Channel.CreateUnbounded<KeyValuePair<uint, string>>();
     private readonly ConcurrentDictionary<uint, Channel<string>> pendingRequests = new();
 
-    // GBXRemote 1 has no handle to correlate requests/responses, so calls must be strictly
-    // sequential (send, then wait for the matching response) to avoid cross-talk between callers.
+    // GBXRemote 1 has no handle to correlate requests/responses,
+    // so calls must be strictly sequential to avoid cross-talk between callers
     private readonly SemaphoreSlim? v1CallSemaphore;
 
     private readonly TcpClient tcp;
@@ -218,10 +218,8 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
     private async Task RunCallbacksAsync(CancellationToken cancellationToken)
     {
-        while (!cancellationToken.IsCancellationRequested)
+        await foreach (var (handle, xml) in callbackChannel.Reader.ReadAllAsync(cancellationToken))
         {
-            var (handle, xml) = await callbackChannel.Reader.ReadAsync(cancellationToken);
-
             var r = new MiniXmlReader(xml);
 
             _ = r.SkipProcessingInstruction();
@@ -234,10 +232,13 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
             var parameters = ReadXmlRpcParams(xml, ref r);
 
-            if (Callback is not null)
+            var callback = Callback;
+            if (callback is null) return;
+
+            await Task.WhenAll(callback.GetInvocationList().Select(async invocation =>
             {
-                await Callback.Invoke(methodName, parameters, cancellationToken);
-            }
+                await ((XmlRpcCallback)invocation).Invoke(methodName, parameters, cancellationToken);
+            }));
         }
     }
 

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -236,6 +236,11 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         return ParseXmlRpcMethodResponse(xmlResult);
     }
 
+    public async Task<object?> CallAsync(string methodName, params object?[] methodParams)
+    {
+        return await CallAsync(methodName, methodParams, CancellationToken.None);
+    }
+
     public async Task<object?> CallAsync(string methodName, CancellationToken cancellationToken = default)
     {
         return await CallAsync(methodName, [], cancellationToken);

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -14,7 +14,11 @@ namespace ManiaAPI.XmlRpc;
 
 public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 {
-    private const string Handshake = "GBXRemote 2";
+    private const string HandshakeV1 = "GBXRemote 1";
+    private const string HandshakeV2 = "GBXRemote 2";
+
+    // GBXRemote 1 messages carry no handle, so a fixed placeholder is used to key pending requests
+    private const uint NoHandle = 0;
 
     private uint handle = 0x80000000;
 
@@ -27,6 +31,7 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     private readonly ConcurrentDictionary<uint, Channel<string>> pendingRequests = new();
 
     private readonly TcpClient tcp;
+    private readonly int version;
     private readonly ILogger<XmlRpcClient> logger;
 
     private readonly NetworkStream stream;
@@ -40,9 +45,10 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
     public event XmlRpcCallback? Callback;
 
-    private XmlRpcClient(TcpClient tcp, ILogger<XmlRpcClient> logger)
+    private XmlRpcClient(TcpClient tcp, int version, ILogger<XmlRpcClient> logger)
     {
         this.tcp = tcp ?? throw new ArgumentNullException(nameof(tcp));
+        this.version = version;
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         stream = tcp.GetStream();
@@ -69,8 +75,8 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     {
         var tcp = new TcpClient();
         await tcp.ConnectAsync(ip, port, cancellationToken);
-        await ValidateHeaderOrThrowAsync(tcp.GetStream(), cancellationToken);
-        return new XmlRpcClient(tcp, logger ?? NullLogger<XmlRpcClient>.Instance);
+        var version = await ValidateHeaderOrThrowAsync(tcp.GetStream(), cancellationToken);
+        return new XmlRpcClient(tcp, version, logger ?? NullLogger<XmlRpcClient>.Instance);
     }
 
     /// <summary>
@@ -91,8 +97,8 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     {
         var tcp = new TcpClient();
         await tcp.ConnectAsync(ip, port, cancellationToken);
-        await ValidateHeaderOrThrowAsync(tcp.GetStream(), cancellationToken);
-        return new XmlRpcClient(tcp, logger ?? NullLogger<XmlRpcClient>.Instance);
+        var version = await ValidateHeaderOrThrowAsync(tcp.GetStream(), cancellationToken);
+        return new XmlRpcClient(tcp, version, logger ?? NullLogger<XmlRpcClient>.Instance);
     }
 
     /// <summary>
@@ -111,11 +117,11 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     {
         var tcp = new TcpClient();
         await tcp.ConnectAsync(endpoint, cancellationToken);
-        await ValidateHeaderOrThrowAsync(tcp.GetStream(), cancellationToken);
-        return new XmlRpcClient(tcp, logger ?? NullLogger<XmlRpcClient>.Instance);
+        var version = await ValidateHeaderOrThrowAsync(tcp.GetStream(), cancellationToken);
+        return new XmlRpcClient(tcp, version, logger ?? NullLogger<XmlRpcClient>.Instance);
     }
 
-    private static async Task ValidateHeaderOrThrowAsync(NetworkStream stream, CancellationToken cancellationToken)
+    private static async Task<int> ValidateHeaderOrThrowAsync(NetworkStream stream, CancellationToken cancellationToken)
     {
         var lengthBuffer = new byte[4];
         await stream.ReadExactlyAsync(lengthBuffer, cancellationToken);
@@ -129,13 +135,14 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         var headerBuffer = new byte[length];
         await stream.ReadExactlyAsync(headerBuffer, cancellationToken);
 
-        for (int i = 0; i < Handshake.Length; i++)
+        var header = Encoding.ASCII.GetString(headerBuffer);
+
+        return header switch
         {
-            if (headerBuffer[i] != Handshake[i])
-            {
-                throw new XmlRpcClientException("GBXRemote header is invalid");
-            }
-        }
+            HandshakeV1 => 1,
+            HandshakeV2 => 2,
+            _ => throw new XmlRpcClientException($"GBXRemote header is invalid: {header}"),
+        };
     }
 
     private async Task ListenAsync(CancellationToken cancellationToken = default)
@@ -144,11 +151,27 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         {
             IsWaitingForMessages = true;
 
-            var payloadPrefix = new byte[8];
-            await stream.ReadExactlyAsync(payloadPrefix, cancellationToken);
+            uint handle;
+            int payloadSize;
 
-            var payloadSize = BitConverter.ToInt32(payloadPrefix, 0);
-            var handle = BitConverter.ToUInt32(payloadPrefix, 4);
+            if (version >= 2)
+            {
+                var payloadPrefix = new byte[8];
+                await stream.ReadExactlyAsync(payloadPrefix, cancellationToken);
+
+                payloadSize = BitConverter.ToInt32(payloadPrefix, 0);
+                handle = BitConverter.ToUInt32(payloadPrefix, 4);
+            }
+            else
+            {
+                // GBXRemote 1 has no handle in the message header
+                var payloadPrefix = new byte[4];
+                await stream.ReadExactlyAsync(payloadPrefix, cancellationToken);
+
+                payloadSize = BitConverter.ToInt32(payloadPrefix, 0);
+                handle = NoHandle;
+            }
+
             var payloadBuffer = new byte[payloadSize];
             await stream.ReadExactlyAsync(payloadBuffer, cancellationToken);
 
@@ -157,7 +180,10 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
             var payload = Encoding.UTF8.GetString(payloadBuffer);
 
             // if handle is sent method (not callback)
-            var isCallback = (handle >> 31) == 0;
+            // GBXRemote 1 has no handle, so distinguish by the XML root element instead.
+            var isCallback = version >= 2
+                ? (handle >> 31) == 0
+                : payload.Contains("<methodCall>", StringComparison.Ordinal);
 
             if (isCallback)
             {
@@ -461,38 +487,66 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
     private async Task<uint> SendXmlPayloadAsync(string xmlPayload, CancellationToken cancellationToken)
     {
-        const int headerSize = sizeof(uint) + sizeof(uint);
-
         var xmlPayloadByteCount = Encoding.UTF8.GetByteCount(xmlPayload);
 
-        // uint32 xmlPayloadByteCount (4 bytes)
-        // uint32 handle (+4 bytes = 8)
-        // bytes xmlPayload (length of xmlPayloadByteCount)
-        var buffer = new byte[xmlPayloadByteCount + headerSize];
-
-        var bufferedXmlPayloadByteCount = Encoding.UTF8.GetBytes(xmlPayload, buffer.AsSpan().Slice(headerSize));
-
-        if (bufferedXmlPayloadByteCount != xmlPayloadByteCount)
+        if (version >= 2)
         {
-            throw new XmlRpcClientException($"Invalid string buffering (expected {xmlPayloadByteCount} bytes, got {bufferedXmlPayloadByteCount} bytes)");
-        }
+            const int headerSize = sizeof(uint) + sizeof(uint);
 
-        if (!BitConverter.TryWriteBytes(buffer, xmlPayloadByteCount))
+            // uint32 xmlPayloadByteCount (4 bytes)
+            // uint32 handle (+4 bytes = 8)
+            // bytes xmlPayload (length of xmlPayloadByteCount)
+            var buffer = new byte[xmlPayloadByteCount + headerSize];
+
+            var bufferedXmlPayloadByteCount = Encoding.UTF8.GetBytes(xmlPayload, buffer.AsSpan().Slice(headerSize));
+
+            if (bufferedXmlPayloadByteCount != xmlPayloadByteCount)
+            {
+                throw new XmlRpcClientException($"Invalid string buffering (expected {xmlPayloadByteCount} bytes, got {bufferedXmlPayloadByteCount} bytes)");
+            }
+
+            if (!BitConverter.TryWriteBytes(buffer, xmlPayloadByteCount))
+            {
+                throw new XmlRpcClientException("Failed to write XML payload byte count to buffer");
+            }
+
+            var handle = GetNextHandle();
+
+            // Write handle as uint32 at offset 4
+            if (!BitConverter.TryWriteBytes(buffer.AsSpan().Slice(4), handle))
+            {
+                throw new XmlRpcClientException("Failed to write handle to buffer");
+            }
+
+            await stream.WriteAsync(buffer, cancellationToken);
+
+            return handle;
+        }
+        else
         {
-            throw new XmlRpcClientException("Failed to write XML payload byte count to buffer");
+            const int headerSize = sizeof(uint);
+
+            // uint32 xmlPayloadByteCount (4 bytes)
+            // bytes xmlPayload (length of xmlPayloadByteCount)
+            // GBXRemote 1 has no handle field
+            var buffer = new byte[xmlPayloadByteCount + headerSize];
+
+            var bufferedXmlPayloadByteCount = Encoding.UTF8.GetBytes(xmlPayload, buffer.AsSpan().Slice(headerSize));
+
+            if (bufferedXmlPayloadByteCount != xmlPayloadByteCount)
+            {
+                throw new XmlRpcClientException($"Invalid string buffering (expected {xmlPayloadByteCount} bytes, got {bufferedXmlPayloadByteCount} bytes)");
+            }
+
+            if (!BitConverter.TryWriteBytes(buffer, xmlPayloadByteCount))
+            {
+                throw new XmlRpcClientException("Failed to write XML payload byte count to buffer");
+            }
+
+            await stream.WriteAsync(buffer, cancellationToken);
+
+            return NoHandle;
         }
-
-        var handle = GetNextHandle();
-
-        // Write handle as uint32 at offset 4
-        if (!BitConverter.TryWriteBytes(buffer.AsSpan().Slice(4), handle))
-        {
-            throw new XmlRpcClientException("Failed to write handle to buffer");
-        }
-
-        await stream.WriteAsync(buffer, cancellationToken);
-
-        return handle;
     }
 
     private uint GetNextHandle()

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -30,6 +30,10 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     private readonly Channel<KeyValuePair<uint, string>> callbackChannel = Channel.CreateUnbounded<KeyValuePair<uint, string>>();
     private readonly ConcurrentDictionary<uint, Channel<string>> pendingRequests = new();
 
+    // GBXRemote 1 has no handle to correlate requests/responses, so calls must be strictly
+    // sequential (send, then wait for the matching response) to avoid cross-talk between callers.
+    private readonly SemaphoreSlim? v1CallSemaphore;
+
     private readonly TcpClient tcp;
     private readonly int version;
     private readonly ILogger<XmlRpcClient> logger;
@@ -50,6 +54,8 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         this.tcp = tcp ?? throw new ArgumentNullException(nameof(tcp));
         this.version = version;
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        v1CallSemaphore = version < 2 ? new SemaphoreSlim(1, 1) : null;
 
         stream = tcp.GetStream();
 
@@ -180,10 +186,10 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
             var payload = Encoding.UTF8.GetString(payloadBuffer);
 
             // if handle is sent method (not callback)
-            // GBXRemote 1 has no handle, so distinguish by the XML root element instead.
+            // GBXRemote 1 has no handle, so distinguish by the actual XML root element instead.
             var isCallback = version >= 2
                 ? (handle >> 31) == 0
-                : payload.Contains("<methodCall>", StringComparison.Ordinal);
+                : IsMethodCallPayload(payload);
 
             if (isCallback)
             {
@@ -276,28 +282,51 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var startTime = Stopwatch.GetTimestamp();
-
-        var handle = await SendXmlPayloadAsync(xmlPayload, cancellationToken);
-
-        if (logger.IsEnabled(LogLevel.Debug))
+        if (v1CallSemaphore is not null)
         {
-            logger.LogDebug("{MethodName} (0x{Handle}) has been sent. Waiting for response...", methodName, handle.ToString("x8"));
+            await v1CallSemaphore.WaitAsync(cancellationToken);
         }
 
-        var channel = GetOrCreatePendingRequestChannel(handle);
-        var xml = await channel.Reader.ReadAsync(cancellationToken);
-
-        pendingRequests.Remove(handle, out _);
-
-        var elapsed = Stopwatch.GetElapsedTime(startTime);
-
-        if (logger.IsEnabled(LogLevel.Debug))
+        try
         {
-            logger.LogDebug("{MethodName} (0x{Handle}) response received (in {ElapsedMilliseconds}ms).", methodName, handle.ToString("x8"), elapsed.TotalMilliseconds);
-        }
+            var startTime = Stopwatch.GetTimestamp();
 
-        return xml;
+            var handle = await SendXmlPayloadAsync(xmlPayload, cancellationToken);
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("{MethodName} (0x{Handle}) has been sent. Waiting for response...", methodName, handle.ToString("x8"));
+            }
+
+            var channel = GetOrCreatePendingRequestChannel(handle);
+            var xml = await channel.Reader.ReadAsync(cancellationToken);
+
+            pendingRequests.Remove(handle, out _);
+
+            var elapsed = Stopwatch.GetElapsedTime(startTime);
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("{MethodName} (0x{Handle}) response received (in {ElapsedMilliseconds}ms).", methodName, handle.ToString("x8"), elapsed.TotalMilliseconds);
+            }
+
+            return xml;
+        }
+        finally
+        {
+            v1CallSemaphore?.Release();
+        }
+    }
+
+    // Checks whether the payload's actual root element is <methodCall> (a server-initiated callback),
+    // as opposed to <methodResponse>/<fault> (a reply to our request). Anchored to the root element
+    // rather than a raw substring search, since response data (e.g. string values) is not guaranteed
+    // to be escaped and could otherwise coincidentally contain the literal text "<methodCall>".
+    private static bool IsMethodCallPayload(string payload)
+    {
+        var declarationEnd = payload.IndexOf("?>", StringComparison.Ordinal);
+        var rootStart = declarationEnd >= 0 ? declarationEnd + 2 : 0;
+        return payload.AsSpan(rootStart).TrimStart().StartsWith("<methodCall>", StringComparison.Ordinal);
     }
 
     private Channel<string> GetOrCreatePendingRequestChannel(uint handle)
@@ -584,6 +613,7 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         cts.Cancel();
         tcp.Dispose();
         cts.Dispose();
+        v1CallSemaphore?.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -606,6 +636,7 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
         tcp.Dispose();
         cts.Dispose();
+        v1CallSemaphore?.Dispose();
 
         GC.SuppressFinalize(this);
     }

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Channels;
 
@@ -29,6 +30,7 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 #endif
     private readonly Channel<KeyValuePair<uint, string>> callbackChannel = Channel.CreateUnbounded<KeyValuePair<uint, string>>();
     private readonly ConcurrentDictionary<uint, Channel<string>> pendingRequests = new();
+    private readonly ConcurrentDictionary<string, List<Func<object?[], CancellationToken, Task>>> routeHandlers = new();
 
     // GBXRemote 1 has no handle to correlate requests/responses,
     // so calls must be strictly sequential to avoid cross-talk between callers
@@ -44,8 +46,8 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
     public bool IsWaitingForMessages { get; private set; }
 
-    public Task ListenTask { get; }
-    public Task CallbackTask { get; }
+    private Task ListenTask { get; }
+    private Task CallbackTask { get; }
 
     public event XmlRpcCallback? Callback;
 
@@ -59,8 +61,24 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
         stream = tcp.GetStream();
 
-        ListenTask = Task.Run(() => ListenAsync(cts.Token));
-        CallbackTask = Task.Run(() => RunCallbacksAsync(cts.Token));
+        ListenTask = Task.Run(async () =>
+        {
+            try
+            {
+                await ListenAsync(cts.Token);
+            }
+            finally
+            {
+                callbackChannel.Writer.TryComplete();
+
+                if (!cts.IsCancellationRequested)
+                {
+                    cts.Cancel();
+                }
+            }
+        });
+
+        CallbackTask = Task.Run(() => ProcessCallbacksAsync(cts.Token));
     }
 
     /// <summary>
@@ -151,6 +169,15 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         };
     }
 
+    public void On(string methodName, Func<object?[], CancellationToken, Task> handler)
+    {
+        routeHandlers.AddOrUpdate(
+            methodName,
+            _ => [handler],
+            (_, list) => { list.Add(handler); return list; }
+        );
+    }
+
     private async Task ListenAsync(CancellationToken cancellationToken = default)
     {
         while (!cancellationToken.IsCancellationRequested)
@@ -216,7 +243,35 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
         }
     }
 
-    private async Task RunCallbacksAsync(CancellationToken cancellationToken)
+    public async IAsyncEnumerable<XmlRpcCallbackMessage> StreamCallbacksAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
+        
+        var streamChannel = Channel.CreateUnbounded<XmlRpcCallbackMessage>();
+
+        Task HandleCallback(string methodName, object?[] parameters, CancellationToken token)
+        {
+            streamChannel.Writer.TryWrite(new XmlRpcCallbackMessage(methodName, parameters));
+            return Task.CompletedTask;
+        }
+
+        Callback += HandleCallback;
+
+        try
+        {
+            await foreach (var message in streamChannel.Reader.ReadAllAsync(linkedCts.Token))
+            {
+                yield return message;
+            }
+        }
+        finally
+        {
+            Callback -= HandleCallback;
+            streamChannel.Writer.TryComplete();
+        }
+    }
+
+    private async Task ProcessCallbacksAsync(CancellationToken cancellationToken)
     {
         await foreach (var (handle, xml) in callbackChannel.Reader.ReadAllAsync(cancellationToken))
         {
@@ -232,12 +287,34 @@ public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 
             var parameters = ReadXmlRpcParams(xml, ref r);
 
+            if (routeHandlers.TryGetValue(methodName, out var handlers))
+            {
+                await Task.WhenAll(handlers.Select(async handler =>
+                {
+                    try
+                    {
+                        await handler.Invoke(parameters, cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Routed handler threw an exception for {MethodName}.", methodName);
+                    }
+                }));
+            }
+
             var callback = Callback;
-            if (callback is null) return;
+            if (callback is null) continue;
 
             await Task.WhenAll(callback.GetInvocationList().Select(async invocation =>
             {
-                await ((XmlRpcCallback)invocation).Invoke(methodName, parameters, cancellationToken);
+                try
+                {
+                    await ((XmlRpcCallback)invocation).Invoke(methodName, parameters, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Global callback threw an exception for {MethodName}.", methodName);
+                }
             }));
         }
     }

--- a/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
+++ b/Src/ManiaAPI.XmlRpc/XmlRpcClient.cs
@@ -12,7 +12,7 @@ using System.Threading.Channels;
 
 namespace ManiaAPI.XmlRpc;
 
-public partial class XmlRpcClient : IDisposable
+public partial class XmlRpcClient : IDisposable, IAsyncDisposable
 {
     private const string Handshake = "GBXRemote 2";
 
@@ -507,6 +507,30 @@ public partial class XmlRpcClient : IDisposable
     {
         cts.Cancel();
         tcp.Dispose();
+        cts.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        cts.Cancel();
+
+        try
+        {
+            await Task.WhenAll(ListenTask, CallbackTask);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected: the listen/callback loops observe the cancellation and stop.
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "XML-RPC background task ended unexpectedly during dispose.");
+        }
+
+        tcp.Dispose();
+        cts.Dispose();
+
         GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
ManiaAPI.XmlRpc
- Added better handling of callback events
  - `On` - handle specific callback without if statements
  - `StreamCallbacksAsync` - async blocking streaming of callbacks with `IAsyncEnumerable`
- Added params support to `CallAsync`
- Added `WaitForCloseAsync`
- Added `IAsyncDisposable`
- Added support for GBXRemote 1